### PR TITLE
fix(npm): prevent hooks to be verified on release

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Commitizen setup test",
   "scripts": {
-    "release": "standard-version"
+    "release": "standard-version --no-verify"
   },
   "keywords": [
     "commitizen",


### PR DESCRIPTION
### General Notes

According to the [standard-version documentation](https://github.com/conventional-changelog/standard-version#prevent-git-hooks) it's required to add the `--no-verify` option to prevent the hooks to be verified during the commit step

**NOTE**:
A PR may have several `wip` commits, each of one referencing the type of change (build, doc, style, etc). The PR title here is adding the `fix` type of change, I don't know if it's going to be included in the [CHANGELOG.md](https://github.com/jairovg/commitizen-test/blob/master/CHANGELOG.md) without using a squash and merge stratety.

Related urls:
* https://github.com/marketplace/actions/conventional-pr-title
* https://github.com/amannn/action-semantic-pull-request

fix #1

### What kind of change does this PR introduce? (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

### Does this PR introduce a breaking change? (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications: