### PR TITLE
build(npm): prevent husky hooks to be verified on release

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Commitizen setup test",
   "scripts": {
-    "release": "standard-version --no-verify"
+    "release": "HUSKY_SKIP_HOOKS=1 standard-version --no-verify"
   },
   "keywords": [
     "commitizen",


### PR DESCRIPTION
### General Notes

> According to the [git documentation](https://git-scm.com/docs/githooks#_prepare_commit_msg), the `prepare-commit-msg` is not suppressed by the `--no-verify` option.

Adding ability to [skip husky hooks](https://github.com/jairovg/commitizen-test/blob/fix/release-commit-hook/package.json#L6) in the release script.

fix #1

### What kind of change does this PR introduce? (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

### Does this PR introduce a breaking change? (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications: