### PR TITLE
fix(github-action): use setup-node beta version and env after run script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v2-beta
         with:
           node-version: '12'
       - name: Clean and install dependencies
         run: npm ci
       - name: Create new release
+        run: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm run release


### PR DESCRIPTION
### General Notes

The latest [stable setup-node](https://github.com/actions/setup-node/releases) is the v1, the v2 is yet in beta. Also, setup the `env` property after the `run` script

fix #6 

### What kind of change does this PR introduce? (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

### Does this PR introduce a breaking change? (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications: